### PR TITLE
Fixing bug that showed a verified message on unverified state

### DIFF
--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -118,8 +118,9 @@ chrome.runtime.onMessage.addListener(function (
   }
 
   const verifiedTextInput = inputs.find((textInput) => verify(textInput));
-  if (verifiedTextInput != null) {
-    sendResponse({ success: true, address: verifiedTextInput.value });
+  // verifiedTextInput returns as {} when find fails for some reason.
+  if (Object.keys(verifiedTextInput as Object).length > 0)  {
+    sendResponse({ success: true, address: verifiedTextInput });
     return;
   }
 


### PR DESCRIPTION
Not ready to merge yet, but aiming to fix the "sticky state" bug that causes the extension to incorrectly verify addresses.

Initial commit fixes an incorrect verification bug.
TODO:
have `inputs` array accurately represent inputs (currently, when pressing "verify", inputs array actually returns an array of empty objects)