### PR TITLE
Add fix null address book bug

### DIFF
--- a/src/address-book/EditAddress.tsx
+++ b/src/address-book/EditAddress.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, TextField } from "@mui/material";
+import { Box, Button, TextField, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import React, { useState } from "react";
 import { AddressContentsInputType, CryptoAddressContents } from "../types";
@@ -12,18 +12,29 @@ export default function EditAddress(props: {
   const { address, contents } = props;
   const [addressVal, setAddressVal] = useState(address);
   const [nameVal, setNameVal] = useState(contents.name);
+  const [error, setError] = useState("");
 
   function save(shouldDelete: boolean) {
+    if (addressVal.length === 0 || nameVal.length === 0) {
+      setError("please fill out all fields and try saving again");
+      return;
+    }
     props.onSave({
       address: addressVal,
       contents: { name: nameVal },
       deleteAddress: shouldDelete,
     });
+    setError("");
   }
 
   return (
     <Grid container>
       <Grid item xs={12}>
+        {error && (
+          <Grid item xs={12}>
+            <Typography color="red">Error: {error}</Typography>
+          </Grid>
+        )}
         <Grid item xs={12}>
           <TextField
             label="Address"


### PR DESCRIPTION
Originally, we allowed null addresses and names in the address book. This caused both UI issues and auto-verified "empty" addresses on every page. This PR removes the ability to add null addresses to the address book.

Close #4 